### PR TITLE
.gitignore improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,9 @@
 /project/uploads/*
 !/project/uploads/.gitkeep
 
+/project/plugins/hello.php
+
+/project/themes/*
+!/project/themes/beth-chernes
+
 node_modules


### PR DESCRIPTION
This change prevents us from accidentally committing WP's default themes and plugins (go away `hello.php`!)